### PR TITLE
Fix build pack errors around OOOOOOOOOOOOOOLDDDD versions of Golang

### DIFF
--- a/.godir
+++ b/.godir
@@ -1,1 +1,0 @@
-github.com/evoila/influxdb-firehose-nozzle

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,10 +1,7 @@
 {
 	"ImportPath": "github.com/18F/riemann-firehose-nozzle",
-	"GoVersion": "go1.5.3",
-	"GodepVersion": "v67",
-	"Packages": [
-		"."
-	],
+	"GoVersion": "go1.7",
+	"GodepVersion": "v79",
 	"Deps": [
 		{
 			"ImportPath": "github.com/amir/raidman",


### PR DESCRIPTION
Go Buildpack 1.8.2 doesn't support this file, and recommend that godep
or glide are used instead. The project already uses godep, I believe.

```
-----> Go Buildpack version 1.8.2
       **ERROR** Deprecated, .godir file found! Please update to supported Godep or Glide dependency managers.
       See https://github.com/tools/godep or https://github.com/Masterminds/glide for usage information.
       **ERROR** Unable to select Go vendor tool: .godir deprecated
```

cc @jmcarp 

![790920457170338082-2](https://cloud.githubusercontent.com/assets/706004/26475701/4369c400-4187-11e7-918c-62aa99988f49.gif)
